### PR TITLE
Fix not using an rgb or hex color in css causing heroku deploy to fail

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -54,7 +54,6 @@
 	.btn-lg {
 		padding: .75rem 1.25rem;
 		font-weight: 700;
-		background-color: : black;
 	}
 }
 // homepage footer


### PR DESCRIPTION
Removing line of CSS used during testing that is both unnecessary and causing deploy to fail.