### PR TITLE
Add schedule_date to lectures

### DIFF
--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -76,6 +76,6 @@ class LecturesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def lecture_params
-    params.require(:lecture).permit(:lecture_name, :lecture_content, :video_link, :teacher_id)
+    params.require(:lecture).permit(:lecture_name, :lecture_content, :video_link, :teacher_id, :schedule_date)
   end
 end

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -3,6 +3,11 @@ class Lecture < ApplicationRecord
   before_destroy :destroy_homeworks
   has_one :homework
 
+  # better presentation of lecture datetime in user local time
+  def scheduled_for_local
+    self.schedule_date.localtime.strftime("%Y/%m/%d at %I:%M%p")
+  end
+
   def has_homework?
     !self.homework.nil?
   end
@@ -12,5 +17,5 @@ class Lecture < ApplicationRecord
       self.homework.destroy
     end
   end
-  
+
 end

--- a/app/views/course_sessions/show.html.erb
+++ b/app/views/course_sessions/show.html.erb
@@ -11,7 +11,7 @@
 
 <div class="container mx-auto">
   <p id="notice"><%= notice %></p>
-  <% @course_session.lectures.each do |lecture| %>
+  <% @course_session.lectures.sort_by{|e| [e[:schedule_date] ? 0 : 1,e[:schedule_date]]}.each do |lecture| %>
     <div class="card bg-white mb-3" style="max-width: 100rem;">
       <div class="card-header">
         <%= lecture.lecture_name %>
@@ -23,7 +23,8 @@
       <div class="card-title p-3">
         <h5><%= lecture.lecture_content %></h5>
       </div>
-      <div class = "card-body px-3 py-1">
+      <div class="card-body px-3 py-1">
+        <p class="text-left"><%= "Lecture Date: " + lecture.schedule_date.to_s if lecture.schedule_date %></p>
         <%= link_to "View Lecture", lecture.video_link, class: "float-left" if lecture.video_link != '' %>
         <% if lecture.has_homework? %>
           <%= link_to lecture.homework.content, homework_path(lecture.homework), class: "float-right" %>

--- a/app/views/course_sessions/show.html.erb
+++ b/app/views/course_sessions/show.html.erb
@@ -24,7 +24,7 @@
         <h5><%= lecture.lecture_content %></h5>
       </div>
       <div class="card-body px-3 py-1">
-        <p class="text-left"><%= "Lecture Date: " + lecture.schedule_date.to_s if lecture.schedule_date %></p>
+        <p class="text-left"><%= "Lecture Date: " + lecture.scheduled_for_local if lecture.schedule_date %></p>
         <%= link_to "View Lecture", lecture.video_link, class: "float-left" if lecture.video_link != '' %>
         <% if lecture.has_homework? %>
           <%= link_to lecture.homework.content, homework_path(lecture.homework), class: "float-right" %>

--- a/app/views/lectures/_form.html.erb
+++ b/app/views/lectures/_form.html.erb
@@ -14,7 +14,7 @@
 
     <div class="form-group">
       <%= form.label :schedule_date, class: "input-group mb-3" %>
-      <%= form.date_field :schedule_date, class: "form-control" %>
+      <%= form.datetime_field :schedule_date, class: "form-control" %>
     </div>
 
     <div class="form-group">

--- a/app/views/lectures/_form.html.erb
+++ b/app/views/lectures/_form.html.erb
@@ -13,6 +13,11 @@
     </div>
 
     <div class="form-group">
+      <%= form.label :schedule_date, class: "input-group mb-3" %>
+      <%= form.date_field :schedule_date, class: "form-control" %>
+    </div>
+
+    <div class="form-group">
       <%= form.label :video_link, class: "input-group mb-3" %>
       <%= form.text_field :video_link, class: "form-control" %>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module CarrotUAdmin
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.time_zone = 'Pacific Time (US & Canada)'
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/db/migrate/20200623134449_add_schedule_date_to_lectures.rb
+++ b/db/migrate/20200623134449_add_schedule_date_to_lectures.rb
@@ -1,0 +1,5 @@
+class AddScheduleDateToLectures < ActiveRecord::Migration[6.0]
+  def change
+    add_column :lectures, :schedule_date, :date
+  end
+end

--- a/db/migrate/20200623182731_change_schedule_date_to_date_time.rb
+++ b/db/migrate/20200623182731_change_schedule_date_to_date_time.rb
@@ -1,0 +1,5 @@
+class ChangeScheduleDateToDateTime < ActiveRecord::Migration[6.0]
+  def change
+    change_column :lectures, :schedule_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_134449) do
+ActiveRecord::Schema.define(version: 2020_06_23_182731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2020_06_23_134449) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "course_session_id"
-    t.date "schedule_date"
+    t.datetime "schedule_date"
     t.index ["course_session_id"], name: "index_lectures_on_course_session_id"
     t.index ["homework_id"], name: "index_lectures_on_homework_id"
     t.index ["teacher_id"], name: "index_lectures_on_teacher_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_22_221841) do
+ActiveRecord::Schema.define(version: 2020_06_23_134449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2020_06_22_221841) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "course_session_id"
+    t.date "schedule_date"
     t.index ["course_session_id"], name: "index_lectures_on_course_session_id"
     t.index ["homework_id"], name: "index_lectures_on_homework_id"
     t.index ["teacher_id"], name: "index_lectures_on_teacher_id"


### PR DESCRIPTION
Add Schedule Date to Lectures to allow for basic ordering of lectures and presentation of schedule date for the intended date the lecture will occur, or the date the lecture did take place.

### Changelog
- Add schedule_date to lecture table
- Add field into views
- Update controller
- Modify course session show page to order lectures by their schedule date with nil last

### Checklist:
 My code follows the style guideline
 I have performed a self-review of my own code
 I have made corresponding changes to the documentation
 Add tests if required

### UI Screenshots:
Lectures changing sort based on Lecture Date
![image](https://user-images.githubusercontent.com/54109441/85437786-28d53680-b559-11ea-8d94-1497e6071541.png)

![image](https://user-images.githubusercontent.com/54109441/85437829-35598f00-b559-11ea-8a4e-fa4f000f70b2.png)

Lecture Form
![image](https://user-images.githubusercontent.com/54109441/85437904-4d311300-b559-11ea-94de-b6e5a254d94d.png)

