### PR TITLE
Set the name on the user based on the email address

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,14 @@
 require "digest"
 
 class User < ApplicationRecord
+  before_save :compute_name_from_email
+
+  # compute the name from the email if it is not already present
+  def compute_name_from_email
+    if self.name.blank?
+      self.name = self.email.split('@').first.split('.').map(&:capitalize).join(' ')
+    end
+  end
 
   # creates MD5 hash of lowercase email and formats image url for gravatar avatar
   def gravatar_url


### PR DESCRIPTION
In general, this is firstname.lastname@instacart.com, but the computation is agnostic. I prefer this to scattering different names around the code base, but as I commented in other PR, we might want to add a `preferred_name` field so people can specify how they want to be referred to as opposed to their legal name as it appears in their email (except for me! 😁)