### PR TITLE
add spacer/fix mentor form bug

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -168,7 +168,7 @@ including none, the skills needed to be a full-stack engineer.
 </p>
 <% faqs.each do |section| %>
   <a name="<%= section[:name] %>" href="#"></a>
-  <h2><%= section[:title] %></h2>
+  <h2 class="mt-5"><%= section[:title] %></h2>
   <div class="accordion" id="faq">
     <% section[:content].each_with_index do |faq, index| %>
       <div class="card">

--- a/app/views/mentors/_form.html.erb
+++ b/app/views/mentors/_form.html.erb
@@ -18,17 +18,17 @@
   <div class="card p-5" style="width: 48rem;">
     <div class="form-group">
       <%= form.label :first_name, class: "input-group mb-3" %>
-      <%= form.text_field :first_name, class: "form-control", value: current_user.first_name %>
+      <%= form.text_field :first_name, class: "form-control", value: @mentor.first_name || current_user.first_name %>
     </div>
 
     <div class="form-group">
       <%= form.label :last_name, class: "input-group mb-3" %>
-      <%= form.text_field :last_name, class: "form-control", value: current_user.last_name %>
+      <%= form.text_field :last_name, class: "form-control", value: @mentor.last_name || current_user.last_name %>
     </div>
 
     <div class="form-group">
       <%= form.label :email, class: "input-group mb-3" %>
-      <%= form.text_field :email, class: "form-control", value: current_user.email %>
+      <%= form.text_field :email, class: "form-control", value: @mentor.email || current_user.email %>
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
FAQ headings seemed a bit close together + I intro'd a bad UX into the Mentor edit page that would replace any existing DB value with the current user values

### FAQ headings:
![image](https://user-images.githubusercontent.com/4888619/86542350-ed782780-bec9-11ea-8eba-9dc89dcc4c25.png)

### Mentor edit:
![image](https://user-images.githubusercontent.com/4888619/86542320-9e31f700-bec9-11ea-888c-a2cfda4fa948.png)
