### PR TITLE
Only display one instance of each student application

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -8,7 +8,7 @@ class AdminsController < ApplicationController
       course_session: @course_session,
       application_complete: true,
       accepted_at: nil
-    ).joins(:application_answers, :user)
+    ).includes(:application_answers, :user)
 
     render "applications"
   end


### PR DESCRIPTION
Fixes multiple display of the same application by using `includes` rather than `joins` in the Rails query.