### PR TITLE
fix mentors faq link, add margins to student signup

### DIFF
--- a/app/views/mentors/new.html.erb
+++ b/app/views/mentors/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container mb-auto py-3 text-center">
   <h2>Volunteer to be a mentor</h2>
-  <p>Thank you for signing up to participate as a Carrot U mentor! Please take a look at the <a>href="/help/index#mentors">FAQ</a> if you have any questions.</p>
+  <p>Thank you for signing up to participate as a Carrot U mentor! Please take a look at the <a href="/help/index#mentors">FAQ</a> if you have any questions.</p>
 </div>
 <div class="container d-flex justify-content-center">
     <%= render 'form', mentor: @mentor %>

--- a/app/views/students/_application.html.erb
+++ b/app/views/students/_application.html.erb
@@ -1,5 +1,10 @@
+<div class="container mb-auto py-3 text-center">
+  <h2>Apply for Carrot U</h2>
+</div>
+
 <%= form_with url: students_application_path do  |form| %>
-  <div class="card w-75">
+<div class="container mx-auto">
+  <div class="card w-75 p-2 mb-4">
     <h4 class="card-title">Basic information</h4>
     <div class="card-body">
       <div class="form-group">
@@ -28,7 +33,7 @@
     </div>
   </div>
 
-  <div class="card w-75">
+  <div class="card w-75 p-2 mb-4">
     <h4 class="card-title">Code Challenge</h4>
     <div class="card-body">
       <div class="form-group">
@@ -47,7 +52,7 @@
     </div>
   </div>
 
-  <div class="card w-75">
+  <div class="card w-75 p-2 mb-4">
     <h4 class="card-title">Project Proposal</h4>
     <div class="card-body">
       <div class="form-group">
@@ -71,7 +76,7 @@
     </div>
   </div>
 
-  <div class="card w-75">
+  <div class="card w-75 p-2 mb-4">
     <h4 class="card-title">You and Carrot U</h4>
     <div class="card-body">
       <div class="form-group">


### PR DESCRIPTION
fix this:
![image](https://user-images.githubusercontent.com/4888619/86940228-660ffb80-c0f7-11ea-98e3-9af08e7df8ac.png)

add margins to this:
![image](https://user-images.githubusercontent.com/4888619/86940042-29dc9b00-c0f7-11ea-81c2-a051236a798a.png)
new header is not centered correctly, seems to be a width issue but doesn't look too terrible
